### PR TITLE
ofono-qt is a dependency of telepathy-ofono

### DIFF
--- a/mci/bionic/unstable.yaml
+++ b/mci/bionic/unstable.yaml
@@ -24,6 +24,8 @@ gitlab.com:
           branch: master
     - libs/telepathy-ofono:
           branch: master
+    - libs/ofono-qt:
+          branch: master
     - apps/llsvplayer:
           branch: master
 


### PR DESCRIPTION
but it was removed from ubuntu in bionic. telepathy-ofono is required for sms and phonecalls using the plasmadialer or spacebar messaging app