### PR TITLE
update aws to main branch

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -517,6 +517,7 @@
     upstream_scm:
       type: git
       url: https://github.com/aws/aws-sdk-cpp.git
+      branch: main
 
 '*invent.kde.org/neon/neon-packaging/kdesdk-devenv-dependencies':
   '*':


### PR DESCRIPTION
main has https://github.com/aws/aws-sdk-cpp/commit/5f90c6e11c1e4a2b9234ecd2414a16de5bee0f4e which fixes the ssl compilation issue