### PR TITLE
Revert "add libvlc-qt for spectacle"

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -1437,12 +1437,7 @@
   '*':
     upstream_scm:
       type: uscan
-      
-'*invent.kde.org/neon/neon-packaging/libvlc-qt':
-  '*':
-    upstream_scm:
-      type: uscan
-      
+
 '*invent.kde.org/neon/extras/qcoro':
   '*':
     upstream_scm:


### PR DESCRIPTION
dropped libvlc-qt and changed to a  qml-module-qtmultimedia runtime dep