### PR TITLE
add javatools temporarily

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -1577,6 +1577,11 @@
 
 ### Backports
 
+'*https://invent.kde.org/neon/backports-jammy/javatools-jammy':
+  '*':
+    upstream_scm:
+      type: uscan
+
 '*invent.kde.org/neon/backports-jammy/yt-dlp':
   '*':
     upstream_scm:


### PR DESCRIPTION
we need to provide an i386 package for libturbo-jpeg.  unfortunately javatools is a required dep and not made multiarch when it is an arch-indep package.  a bug and patch have been filed upstream in salsa.