### PR TITLE
build calligra from master 

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -14,12 +14,6 @@
   '*':
     upstream_scm:
 
-'*invent.kde.org/neon/extras/calligra':
-  '*':
-    upstream_scm:
-      type: tarball
-      url: https://download.kde.org/Attic/calligra/3.2.1/calligra-3.2.1.tar.xz
-
 # KF6
 
 '*invent.kde.org/neon/qt6/qt6-phonon':


### PR DESCRIPTION
as the old tarball doesn't build against newer fontconfig and there are still commits going in to master