### PR TITLE
make appstream git in unstable

### DIFF
--- a/overrides/base.yaml
+++ b/overrides/base.yaml
@@ -48,9 +48,13 @@
 ### Backports-Jammy ###
 
 '*invent.kde.org/neon/backports-jammy/appstream-jammy2':
-  '*':
+  '{Neon/release,Neon/stable}':
     upstream_scm:
       type: uscan
+  'Neon/unstable':
+    upstream_scm:
+      url: https://github.com/ximion/appstream.git
+      branch: main
 
 '*invent.kde.org/neon/backports-jammy/callaudiod':
   '*':


### PR DESCRIPTION
plasma-desktop and plasma-discover require the as of yet unreleased appstream-qt 1.0